### PR TITLE
Parse inputs as an array instead of string

### DIFF
--- a/scripts/generate-config.js
+++ b/scripts/generate-config.js
@@ -9,8 +9,8 @@ const template = fs.readFileSync("config/codeql-template.yml", "utf8")
 const { REPO, PATHS_IGNORED, RULES_EXCLUDED } = process.env
 const inputs = {
   repo: REPO,
-  pathsIgnored: PATHS_IGNORED ? PATHS_IGNORED.split("\n").filter((line) => line.trim() !== "") : [],
-  rulesExcluded: RULES_EXCLUDED ? RULES_EXCLUDED.split("\n").filter((line) => line.trim() !== "") : [],
+  pathsIgnored: PATHS_IGNORED ? PATHS_IGNORED.filter((line) => line.trim() !== "") : [],
+  rulesExcluded: RULES_EXCLUDED ? RULES_EXCLUDED.filter((line) => line.trim() !== "") : [],
 }
 console.log(`>>>>>inputs: `)
 console.log(JSON.stringify(inputs, null, 2))


### PR DESCRIPTION
This PR switches to expecting PATHS_IGNORED as a string to being an array. This is due to a change in our interface.