### PR TITLE
Add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @metamask/application-security


### PR DESCRIPTION
As part of our refinement to better gate access to changes, this PR adds a CODEOWNER requirement to be met prior to changes being merged.