### PR TITLE
bump codeql action version to v4

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -51,7 +51,7 @@ runs:
         RULES_EXCLUDED: ${{ inputs.rules_excluded}}
         
     - name: Initialize CodeQL  
-      uses: github/codeql-action/init@v3
+      uses: github/codeql-action/init@v4
       with:
         config-file: ${{ github.workspace }}/${{ env.ACTION_REPO_NAME }}/codeql-config-generated.yml
         languages: ${{ steps.generate-config.outputs.languages }}
@@ -59,13 +59,13 @@ runs:
 
     - name: Run CodeQL Analysis
       id: codeql-analysis
-      uses: github/codeql-action/analyze@v3
+      uses: github/codeql-action/analyze@v4
       with:
         upload: false
         checkout_path: ${{ github.workspace }}/${{ inputs.repo }}
 
     - name: Upload SARIF file
-      uses: github/codeql-action/upload-sarif@v3
+      uses: github/codeql-action/upload-sarif@v4
       with:
         sarif_file: ${{ steps.codeql-analysis.outputs.sarif-output }}
         category: my-analysis-tool


### PR DESCRIPTION
There is an issue where codeql marks alert as fixed when a file was modified with unrelated changes. Then it reopens new alert for the same ruleid. Skewing our data.

V4 release makes changes to how sarif is being uploaded, this might potentially resolve our issue. Certainly no harm no update.

https://github.com/github/codeql-action/blob/main/CHANGELOG.md#:~:text=2.17.6.%20%233223-,When,-SARIF%20files%20are

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Upgrade `github/codeql-action` steps (init, analyze, upload-sarif) from v3 to v4 in `action.yaml`.
> 
> - **CI / GitHub Action**:
>   - Update `action.yaml` to use `github/codeql-action` v4:
>     - `init@v4` (from v3)
>     - `analyze@v4` (from v3)
>     - `upload-sarif@v4` (from v3)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fc2e3254e73a5060b26288844c33f689dddf12ea. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->